### PR TITLE
[Hotfix 1] GrayScale 오타 수정 & Text 컴포넌트 태그 변경

### DIFF
--- a/app/components/Text.tsx
+++ b/app/components/Text.tsx
@@ -28,8 +28,10 @@ export default function Text({
   };
 
   return (
-    <p className={`${sizeConfig[size]} ${weightConfig[weight]} ${className}`}>
+    <span
+      className={`${sizeConfig[size]} ${weightConfig[weight]} ${className}`}
+    >
       {children}
-    </p>
+    </span>
   );
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -36,7 +36,7 @@ module.exports = {
         Grayscale: {
           5: "#F3F3F3",
           10: "#E6E6E6",
-          20: "#CCDEFF",
+          20: "#CCCCCC",
           30: "#B3B3B3",
           40: "#999999",
           50: "#808080",


### PR DESCRIPTION
## 구현 목적
공통 반영사항 내 잘못된 값 수정 및 태그 변경

## What is this PR?

> 어떤 기능 구현했는지 간단하게 명시

- [x] tailwind.config.js 내 Grayscale값 오타 수정
- [x] Text 컴포넌트 태그 변경 (p태그에서 span태그로 변경)

## Changes

> 어떤 위험이나 장애가 발견되었는지
> 무슨 이유로 코드를 변경했는지

1. Grayscale alias 설정 중 20에 해당하는 값이 잘못 설정되어있어서 변경하였습니다. 

2. Text 컴포넌트의 활용범위를 높이기 위해 span태그로 변경하였습니다. 본 컴포넌트가 버튼 컴포넌트 안에 사용되는 경우 p태그는 웹표준에 어긋나므로 span태그로 변경하는 것으로 팀원들과 합의하였습니다. 


## Review point

> 어떤 부분에 리뷰어가 집중하면 좋을지(가이드라인 제시)

1. Grayscale 20 값
2. Text 컴포넌트 태그

## Challenge point

> 어려웠던 점 (선택사항)

1. rebase로 인해 커밋의 해시값이 변경된다는 사실을 뒤늦게 인지하고 develop 브랜치를 삭제하였습니다. 본 PR을 반영한 Main 브랜치를 바탕으로 develop 브랜치를 재생성할 예정입니다. 