### PR TITLE
Feat:: Accordion 컴포넌트 생성

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -43,6 +43,8 @@
     "no-multiple-empty-lines": "error", // 여러 줄 공백 금지
     "semi": ["error", "always"], // 끝 semi 콜론 사용
     "eqeqeq": "error",
-    "no-unused-vars": "warn" // 사용하지 않은 변수 경고처리
+    "no-unused-vars": "warn", // 사용하지 않은 변수 경고처리
+    "import/extensions": "off",
+    "import/export": "off"
   }
 }

--- a/app/assets/toggleButton.svg
+++ b/app/assets/toggleButton.svg
@@ -1,0 +1,3 @@
+<svg width="13" height="15" viewBox="0 0 13 15" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M0.193848 14.8032L0.193848 0.506348L12.2095 7.6626L0.193848 14.8032Z" fill="#030303"/>
+</svg>

--- a/app/components/Accordion/Accordion.tsx
+++ b/app/components/Accordion/Accordion.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { useState, SyntheticEvent } from "react";
+import Content from "./Content.tsx";
+import Title from "./Title.tsx";
+
+export default function Accordion() {
+  const [clicked, setClicked] = useState(false);
+
+  const isClicked = (e: SyntheticEvent<HTMLButtonElement>) => {
+    e.preventDefault();
+    setClicked(prev => !prev);
+  };
+
+  return (
+    <div className="w-[34.375rem]">
+      {clicked ? (
+        <>
+          <Title onClick={isClicked} className="rotate-90 transition-all">
+            타이틀
+          </Title>
+          <Content>내용</Content>
+        </>
+      ) : (
+        <Title onClick={isClicked} className="transition-all">
+          타이틀
+        </Title>
+      )}
+    </div>
+  );
+}

--- a/app/components/Accordion/Accordion.tsx
+++ b/app/components/Accordion/Accordion.tsx
@@ -1,10 +1,15 @@
 "use client";
 
-import { useState, SyntheticEvent } from "react";
+import { useState, SyntheticEvent, ReactNode } from "react";
 import Content from "./Content.tsx";
 import Title from "./Title.tsx";
 
-export default function Accordion() {
+type AccordionProps = {
+  title: ReactNode;
+  content: ReactNode;
+};
+
+export default function Accordion({ title, content }: AccordionProps) {
   const [clicked, setClicked] = useState(false);
 
   const isClicked = (e: SyntheticEvent<HTMLButtonElement>) => {
@@ -17,13 +22,13 @@ export default function Accordion() {
       {clicked ? (
         <>
           <Title onClick={isClicked} className="rotate-90 transition-all">
-            타이틀
+            {title}
           </Title>
-          <Content>내용</Content>
+          <Content>{content}</Content>
         </>
       ) : (
         <Title onClick={isClicked} className="transition-all">
-          타이틀
+          {title}
         </Title>
       )}
     </div>

--- a/app/components/Accordion/Content.tsx
+++ b/app/components/Accordion/Content.tsx
@@ -1,0 +1,16 @@
+import { ReactNode } from "react";
+
+type ContentProps = {
+  children: ReactNode;
+  className?: string;
+};
+
+export default function Content({ children, className }: ContentProps) {
+  return (
+    <div
+      className={`bg-Grayscale-5 rounded-lg text-Grayscale-60 p-5 ${className}`}
+    >
+      <p>{children}</p>
+    </div>
+  );
+}

--- a/app/components/Accordion/Title.tsx
+++ b/app/components/Accordion/Title.tsx
@@ -1,0 +1,21 @@
+import Image from "next/image";
+import { ReactNode, SyntheticEvent } from "react";
+import toggleButton from "@/app/assets/toggleButton.svg";
+
+type TitleProps = {
+  children: ReactNode;
+  className?: string;
+  onClick: (event: SyntheticEvent<HTMLButtonElement, Event>) => void;
+};
+export default function Title({ children, className, onClick }: TitleProps) {
+  return (
+    <button
+      type="button"
+      className="flex mb-3 cursor-pointer items-center w-full"
+      onClick={onClick}
+    >
+      <Image src={toggleButton} alt="토글 버튼" className={className} />
+      <span className="ml-2">{children}</span>
+    </button>
+  );
+}

--- a/app/components/Accordion/index.ts
+++ b/app/components/Accordion/index.ts
@@ -1,0 +1,3 @@
+export * from "./Title";
+export * from "./Content";
+export * from "./Accordion";


### PR DESCRIPTION
## What is this PR?

> 어떤 기능 구현했는지 간단하게 명시

- [x] 타이틀 클릭했을 때 컨텐츠 내용이 보이도록 구현

## Changes

> 어떤 위험이나 장애가 발견되었는지
> 무슨 이유로 코드를 변경했는지

### 변경 전
- 처음에는 Accordion에 props를 전달하지 않고 임의로 타이틀과 컨텐츠를 넣게 함
- 사용자를 고려했을 때 Accordion 컴포넌트 안에서 내용을 작성하기보다 바깥에서 props로 받아주는게 좋다고 생각함
```ts
export default function Accordion() {
  const [clicked, setClicked] = useState(false);

  const isClicked = (e: SyntheticEvent<HTMLButtonElement>) => {
    e.preventDefault();
    setClicked(prev => !prev);
  };

  return (
    <div className="w-[34.375rem]">
      {clicked ? (
        <>
          <Title onClick={isClicked} className="rotate-90 transition-all">
            타이틀
          </Title>
          <Content>내용</Content>
        </>
      ) : (
        <Title onClick={isClicked} className="transition-all">
          타이틀
        </Title>
      )}
    </div>
  );
}
```

### 변경 후
- props를 받도록 설정해 사용하기 더 편하게 코드를 개선함
```ts
export default function Accordion({ title, content }: AccordionProps) {
  const [clicked, setClicked] = useState(false);

  const isClicked = (e: SyntheticEvent<HTMLButtonElement>) => {
    e.preventDefault();
    setClicked(prev => !prev);
  };

  return (
    <div className="w-[34.375rem]">
      {clicked ? (
        <>
          <Title onClick={isClicked} className="rotate-90 transition-all">
            {title}
          </Title>
          <Content>{content}</Content>
        </>
      ) : (
        <Title onClick={isClicked} className="transition-all">
          {title}
        </Title>
      )}
    </div>
  );
}
```

## Review point

> 어떤 부분에 리뷰어가 집중하면 좋을지(가이드라인 제시)
props를 바깥에서 받도록 한 후 Accordion을 쓰는 곳에서 
```ts
<Accordion title="타이틀" content="내용" />
```
이라고 작성했을 때 title, content가 들어가도록 코드를 개선했습니다.
바꾼 부분이 더 좋은지 같이 봐주세요! 

## Challenge point

> 어려웠던 점 (선택사항)
