### PR TITLE
Update:: Toast padding값 수정

### DIFF
--- a/app/components/Toast/Toast.tsx
+++ b/app/components/Toast/Toast.tsx
@@ -33,7 +33,7 @@ export default function Toast({
       toastStyle = "text-Meaningful-red bg-[#FCF5F5] border-Meaningful-red";
       break;
     case "With Action":
-      actionButton = "text-Primary-40 absolute right-5 top-[30px]";
+      actionButton = "text-Primary-40 absolute right-5 top-[20px]";
       titleStyle = "block text-Grayscale-80";
       break;
     case "With Title":
@@ -44,7 +44,7 @@ export default function Toast({
   }
   return (
     <div
-      className={`relative w-[360px] shadow-toast rounded-[10px] border px-5 py-6 ${toastStyle}`}
+      className={`relative w-[360px] shadow-toast rounded-[10px] border px-5 py-4 ${toastStyle}`}
     >
       {title && (
         <Title size={titleSize} className={titleStyle}>


### PR DESCRIPTION
## What is this PR?

> 어떤 기능 구현했는지 간단하게 명시

- [x] 디자인시스템 패키지 배포 후 적용했을 때 padding값 달랐던 문제 해결

## Changes

> 어떤 위험이나 장애가 발견되었는지
> 무슨 이유로 코드를 변경했는지

Toast 컴포넌트를 쓰는 다른 팀원분께서 실제로 쓰이는 Toast의 padding값이 디자인시스템 피그마에 있는 padding값과 달랐던 문제를 발견했습니다.
실제로 쓰이는 부분들에서도 너비값이 각각 달라 디자이너분과 소통 후 너비값을 360px로 고정 후 padding값을 기존 23px에서 16px로 변경했습니다. 
또한, `With Action` 에서 버튼이 포함되는 `type`은 버튼의 위치를 조정했습니다.

## Screenshot

> 관련 스크린샷
- 기존 디자인시스템 디자인 (위아래 padding 23px)
<img width="484" alt="스크린샷 2023-08-09 오후 3 12 12" src="https://github.com/sniperfactory-official/sfac-designkit-react/assets/111109573/69f3696d-b7ea-4845-ad0a-aa502d005793">


- 실제 쓰이는 부분의 Toast 디자인 (위아래 padding 16px)
<img width="471" alt="스크린샷 2023-08-09 오후 3 15 26" src="https://github.com/sniperfactory-official/sfac-designkit-react/assets/111109573/3f9df869-f824-453f-81d8-fbb2193f51e6">
